### PR TITLE
Add Pulse scope

### DIFF
--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -23,8 +23,9 @@ Dictionary<string, string> userAttributes = new()
     //{ "[User Attribute Name]", "[User Attribute Value]" }
 };
 
-// Remove 'embed_authoring' scope if Authoring is not needed.
-string[] scopes = new[] { "tableau:views:embed", "tableau:views:embed_authoring" };
+// Remove 'tableau:views:embed_authoring' scope if Authoring is not needed.
+// Remove 'tableau:insights:embed' scope if Pulse is not needed.
+string[] scopes = new[] { "tableau:views:embed", "tableau:views:embed_authoring", "tableau:insights:embed" };
 
 #endregion
 

--- a/java/src/main/java/JWT.java
+++ b/java/src/main/java/JWT.java
@@ -32,8 +32,9 @@ public class JWT {
         Calendar expiry = Calendar.getInstance();
         expiry.add(Calendar.MINUTE, (int)tokenExpiryInMinutes);
 
-        // Remove 'embed_authoring' scope if Authoring is not needed.
-        String[] scopes = {"tableau:views:embed", "tableau:views:embed_authoring" };
+        // Remove 'tableau:views:embed_authoring' scope if Authoring is not needed.
+        // Remove 'tableau:insights:embed' scope if Pulse is not needed.
+        String[] scopes = {"tableau:views:embed", "tableau:views:embed_authoring", "tableau:insights:embed" };
 
         UUID myGeneratedId = UUID.randomUUID();
 

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -9,9 +9,12 @@ function generateJwt() {
   const secret = "[secretvalue]";
   const secretId = "[connectedAppSecretId]";
   const clientId = "[connectedAppClientId]";
-  const scopes = ["tableau:views:embed", "tableau:views:embed_authoring"];
   const userId = "[tableau username]";
   const tokenExpiryInMinutes = 1; // Max of 10 minutes.
+
+  // Remove 'tableau:views:embed_authoring' scope if Authoring is not needed.
+  // Remove 'tableau:insights:embed' scope if Pulse is not needed.
+  const scopes = ["tableau:views:embed", "tableau:views:embed_authoring", "tableau:insights:embed"];
 
   const userAttributes = {
     //  User attributes are optional.

--- a/python/get_jwt.py
+++ b/python/get_jwt.py
@@ -12,8 +12,13 @@ clientId = "[Tableau Connected App Direct Trust Client ID]"
 username = "[Tableau Username]"
 tokenExpiryInMinutes = 1  # Max of 10 minutes.
 
-# Remove 'embed_authoring' scope if Authoring is not needed.
-scopes = ["tableau:views:embed", "tableau:views:embed_authoring"]
+# Remove 'tableau:views:embed_authoring' scope if Authoring is not needed.
+# Remove 'tableau:insights:embed' scope if Pulse is not needed.
+scopes = [
+    "tableau:views:embed",
+    "tableau:views:embed_authoring",
+    "tableau:insights:embed",
+]
 
 kid = secretId
 iss = clientId


### PR DESCRIPTION
These changes add the `tableau:insights:embed` scope to the array of scopes as an example for users who are embedding Pulse metrics.